### PR TITLE
Improve combo point duration tracking system

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -3268,6 +3268,28 @@ SlashCmdList["CLEVEROID"] = function(msg)
         return
     end
 
+    -- combotrack (show combo point tracking info)
+    if cmd == "combotrack" or cmd == "combo" then
+        if CleveRoids.ShowComboTracking then
+            CleveRoids.ShowComboTracking()
+        else
+            CleveRoids.Print("Combo point tracking not available")
+        end
+        return
+    end
+
+    -- comboclear (clear combo tracking data)
+    if cmd == "comboclear" then
+        if CleveRoids.ComboPointTracking then
+            CleveRoids.ComboPointTracking = {}
+            CleveRoids.ComboPointTracking.byID = {}
+            CleveRoids.Print("Combo point tracking data cleared")
+        else
+            CleveRoids.Print("Combo point tracking not available")
+        end
+        return
+    end
+
     -- Unknown command fallback
     CleveRoids.Print("Usage:")
     DEFAULT_CHAT_FRAME:AddMessage("/cleveroid - Show current settings")
@@ -3283,6 +3305,9 @@ SlashCmdList["CLEVEROID"] = function(msg)
     DEFAULT_CHAT_FRAME:AddMessage('/cleveroid addimmune "<NPC>" <school> [buff] - Add immunity')
     DEFAULT_CHAT_FRAME:AddMessage('/cleveroid removeimmune "<NPC>" <school> - Remove immunity')
     DEFAULT_CHAT_FRAME:AddMessage('/cleveroid clearimmune [school] - Clear immunity data')
+    DEFAULT_CHAT_FRAME:AddMessage("|cffffaa00Combo Point Tracking:|r")
+    DEFAULT_CHAT_FRAME:AddMessage('/cleveroid combotrack - Show combo point tracking info')
+    DEFAULT_CHAT_FRAME:AddMessage('/cleveroid comboclear - Clear combo tracking data')
 end
 
 SLASH_CLEAREQUIPQUEUE1 = "/clearequipqueue"

--- a/README.md
+++ b/README.md
@@ -31,10 +31,13 @@ Check slash command and all conditional lists for new usages!
 * `/cleveroid refresh X` - Set refresh rate (1 to 10 updates per second. Default: 5)
 * `/cleveroid learn <spellID> <duration>` - Manually set spell duration in seconds
 * `/cleveroid forget <spellID|all>` - Forget learned spell duration(s)
-* `/cleveroid listimmune [school]`           - List all or specific school immunities
-* `/cleveroid addimmune "<NPC>" <school> [buff]`  - Add manual immunity
+* `/cleveroid debug [0|1]` - Toggle learning debug messages
+* `/cleveroid listimmune [school]` - List all or specific school immunities
+* `/cleveroid addimmune "<NPC>" <school> [buff]` - Add manual immunity
 * `/cleveroid removeimmune "<NPC>" <school>` - Remove immunity
-* `/cleveroid clearimmune [school]`          - Clear data
+* `/cleveroid clearimmune [school]` - Clear immunity data
+* `/cleveroid combotrack` - Show combo point tracking info (Rip, Rupture, Kidney Shot)
+* `/cleveroid comboclear` - Clear combo tracking data
 
 --- 
 
@@ -170,6 +173,25 @@ The system includes pre-configured durations for 329+ debuffs across all classes
 - **Priest:** Shadow Word: Pain, Devouring Plague, Mind Flay, etc.
 - **Paladin:** Judgements, Hammer of Justice, etc.
 - **Shaman:** Flame Shock, Frost Shock, etc.
+
+### Combo Point Scaling
+The addon automatically tracks combo point finishers that scale duration with combo points:
+- **Rogue Rupture** (all ranks): 8s base + 2s per combo point (8s @ 1 CP, 16s @ 5 CP)
+- **Rogue Kidney Shot**: Rank 1: 1s + 1s per CP, Rank 2: 2s + 1s per CP
+- **Druid Rip** (all ranks): 12s base + 4s per combo point (12s @ 1 CP, 28s @ 5 CP)
+
+The system automatically detects combo points at cast time and calculates the correct duration:
+```lua
+-- Will show accurate duration based on combo points used
+/cast [nodebuff:Rip] Rip
+/cast [debuff:Rip<4] Rip
+
+-- Rupture duration tracking with combo point awareness
+/cast [nodebuff:Rupture] Rupture
+/cast [debuff:Rupture<2] Rupture
+```
+
+Use `/cleveroid combotrack` to see recent combo finisher casts and their calculated durations.
 
 ### Technical Details
 - Uses **UNIT_CASTEVENT** for precise cast detection (only tracks successful hits)


### PR DESCRIPTION
Major enhancements to the combo point finisher tracking system:

**ComboPointTracker.lua:**
- Added spell ID-based tracking (ComboScalingSpellsByID table)
- All Rupture ranks (1943, 8639, 8640, 11273, 11274, 11275): 8s + 2s per CP
- Kidney Shot ranks (408, 8643): Rank 1: 1s + 1s per CP, Rank 2: 2s + 1s per CP
- Druid Rip ranks (1079, 9492, 9493, 9752, 9894, 9896): 12s + 4s per CP (corrected from 10s + 2s)
- New TrackComboPointCastByID() function for UNIT_CASTEVENT integration
- Initialize spell_tracking table to prevent nil errors
- Consistent debug output using CleveRoids.debug flag

**Utility.lua (libdebuff integration):**
- UNIT_CASTEVENT handler now checks combo scaling spells first
- Calls TrackComboPointCastByID() before normal duration lookup
- Learning system skips combo spells (they're dynamically calculated)
- Improved debug messages distinguish combo spells from regular spells

**Core.lua (console commands):**
- Added /cleveroid combotrack - Display recent combo finisher casts
- Added /cleveroid comboclear - Clear combo tracking data
- Updated help text with combo point tracking section

**README.md:**
- New "Combo Point Scaling" section with examples
- Updated settings documentation with new commands
- Added /cleveroid debug to settings list
- Example macros showing combo point-aware debuff conditionals

This system ensures accurate duration tracking for:
- Rogue: Rupture (8-16s), Kidney Shot (1-6s)
- Druid: Rip (12-28s)

All durations are now calculated based on actual combo points used at cast time.