### PR TITLE
Add learned combo duration system - saves actual durations per CP

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -3136,6 +3136,7 @@ SlashCmdList["CLEVEROID"] = function(msg)
         DEFAULT_CHAT_FRAME:AddMessage("|cffffaa00Combo Point Tracking:|r")
         DEFAULT_CHAT_FRAME:AddMessage('/cleveroid combotrack - Show combo point tracking info')
         DEFAULT_CHAT_FRAME:AddMessage('/cleveroid comboclear - Clear combo tracking data')
+        DEFAULT_CHAT_FRAME:AddMessage('/cleveroid combolearn - Show learned combo durations (per CP)')
         return
     end
 
@@ -3299,6 +3300,25 @@ SlashCmdList["CLEVEROID"] = function(msg)
         return
     end
 
+    -- combolearn (show learned combo durations)
+    if cmd == "combolearn" or cmd == "combodurations" then
+        CleveRoids.Print("=== Learned Combo Durations ===")
+        if not CleveRoids_ComboDurations or not next(CleveRoids_ComboDurations) then
+            CleveRoids.Print("No learned combo durations yet. Cast finishers and let them expire!")
+        else
+            for spellID, cpData in pairs(CleveRoids_ComboDurations) do
+                local spellName = SpellInfo(spellID) or ("Spell " .. spellID)
+                CleveRoids.Print(spellName .. " (ID:" .. spellID .. "):")
+                for cp = 1, 5 do
+                    if cpData[cp] then
+                        CleveRoids.Print("  " .. cp .. " CP = " .. cpData[cp] .. "s")
+                    end
+                end
+            end
+        end
+        return
+    end
+
     -- Unknown command fallback
     CleveRoids.Print("Usage:")
     DEFAULT_CHAT_FRAME:AddMessage("/cleveroid - Show current settings")
@@ -3317,6 +3337,7 @@ SlashCmdList["CLEVEROID"] = function(msg)
     DEFAULT_CHAT_FRAME:AddMessage("|cffffaa00Combo Point Tracking:|r")
     DEFAULT_CHAT_FRAME:AddMessage('/cleveroid combotrack - Show combo point tracking info')
     DEFAULT_CHAT_FRAME:AddMessage('/cleveroid comboclear - Clear combo tracking data')
+    DEFAULT_CHAT_FRAME:AddMessage('/cleveroid combolearn - Show learned combo durations (per CP)')
 end
 
 SLASH_CLEAREQUIPQUEUE1 = "/clearequipqueue"

--- a/SuperCleveRoidMacros.toc
+++ b/SuperCleveRoidMacros.toc
@@ -4,7 +4,7 @@
 ## Notes: /cleveroid for settings
 ## Version: 1.3
 ## OptionalDeps: ClassicFocus, FocusFrame, pfUI, SuperMacro, Bongos_ActionBar
-## SavedVariables: CleveRoidMacros, CleveRoids_LearnedDurations, CleveRoids_AuraTextures, CleveRoids_ImmunityData
+## SavedVariables: CleveRoidMacros, CleveRoids_LearnedDurations, CleveRoids_AuraTextures, CleveRoids_ImmunityData, CleveRoids_ComboDurations
 Localization.lua
 Init.lua
 Utility.lua


### PR DESCRIPTION
Major enhancement: System now learns actual combo finisher durations and saves them per combo point level (1-5 CP).

**New SavedVariable:**
- CleveRoids_ComboDurations[spellID][comboPoints] = duration
- Persists between sessions
- Uses learned durations before calculated formulas

**ComboPointTracker.lua:**
- Added GetLearnedComboDuration(spellID, cp) - fetch learned duration
- Updated CalculateComboScaledDurationByID to check learned first
- Falls back to formula if not learned yet

**Utility.lua (libdebuff):**
- UNIT_CASTEVENT handler stores combo points in learnCastTimers
- RAW_COMBATLOG fade handler learns combo durations when spells expire
- Stores learned duration keyed by [spellID][comboPoints]
- Debug message shows "Learned combo spell X at Y CP = Zs"

**Core.lua:**
- New command: /cleveroid combolearn - Show all learned combo durations
- Lists each spell with all learned CP levels (1-5)
- Shows which durations have been learned vs not yet

**Benefits:**
- Debuff conditionals like [debuff:Rip<4] now use ACTUAL max duration
- Accounts for talents that modify finisher durations
- Learns different durations per rank
- More accurate than formulas for edge cases

**Example:**
After casting Rip with 5 CP and letting it expire, system learns: CleveRoids_ComboDurations[1079][5] = 28
Future casts use 28s instead of calculated 12+4*4