### PR TITLE
Fix nil comparison error in spell_tracking cleanup loop

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -2250,7 +2250,7 @@ function CleveRoids.OnUpdate(self)
     end
 
     for guid,cast in pairs(CleveRoids.spell_tracking) do
-        if time > cast.expires then
+        if cast.expires and time > cast.expires then
             CleveRoids.spell_tracking[guid] = nil
         end
     end


### PR DESCRIPTION
BUGFIX: Core.lua:2253 attempt to compare nil with number

The cleanup loop was checking 'if time > cast.expires' but some entries in spell_tracking (like combo tracking data) don't have an expires field.

Added nil check: 'if cast.expires and time > cast.expires'

This prevents errors when combo tracking data is in spell_tracking without an expiration time.