### PR TITLE
Fix pfUI AddEffect timing - use name-based tracking instead of ID

### DIFF
--- a/Compatibility/pfUI.lua
+++ b/Compatibility/pfUI.lua
@@ -152,27 +152,16 @@ function Extension.HookPfUILibdebuff()
             -- effect is a spell name, not ID
             -- Check if this is a combo scaling spell by name
             if CleveRoids.IsComboScalingSpell and CleveRoids.IsComboScalingSpell(effect) then
-                -- Try to get learned duration for this combo spell
-                local spellData = CleveRoids.GetComboScalingData(effect)
-                if spellData then
-                    -- Find the spell ID for this effect
-                    for spellID, data in pairs(CleveRoids.ComboScalingSpellsByID) do
-                        if data.name == effect then
-                            -- Check if we have tracking data
-                            if CleveRoids.ComboPointTracking and CleveRoids.ComboPointTracking.byID and
-                               CleveRoids.ComboPointTracking.byID[spellID] then
-                                local tracking = CleveRoids.ComboPointTracking.byID[spellID]
-                                if tracking.duration then
-                                    duration = tracking.duration
-                                    if CleveRoids.debug then
-                                        DEFAULT_CHAT_FRAME:AddMessage(
-                                            string.format("|cff00ff00[pfUI AddEffect Hook]|r Overriding %s duration to %ds",
-                                                effect, duration)
-                                        )
-                                    end
-                                    break
-                                end
-                            end
+                -- Use name-based tracking which is populated BEFORE pfUI's AddEffect
+                if CleveRoids.ComboPointTracking and CleveRoids.ComboPointTracking[effect] then
+                    local tracking = CleveRoids.ComboPointTracking[effect]
+                    if tracking.duration and (GetTime() - tracking.cast_time) < 0.5 then
+                        duration = tracking.duration
+                        if CleveRoids.debug then
+                            DEFAULT_CHAT_FRAME:AddMessage(
+                                string.format("|cff00ff00[pfUI AddEffect Hook]|r Overriding %s duration to %ds (from name tracking)",
+                                    effect, duration)
+                            )
                         end
                     end
                 end


### PR DESCRIPTION
CRITICAL TIMING FIX: pfUI's AddEffect fires BEFORE UNIT_CASTEVENT!

Event sequence:
1. CastSpell → Extension hooks → name-based tracking stores 5 CP, 18s ✓
2. pfUI AddPending → GetDuration (base 10s)
3. SPELLCAST_STOP → pfUI AddEffect fires
4. Our AddEffect hook fires (ID tracking doesn't exist yet!) ✗
5. UNIT_CASTEVENT → ID-based tracking created ✓

Solution: Use name-based tracking (available at step 4) instead of ID-based tracking (not created until step 5).

Changed pfUI AddEffect hook to:
- Use CleveRoids.ComboPointTracking[effect] (name-based)
- Check cast_time < 0.5s to ensure freshness
- This data exists when pfUI calls AddEffect

Now shows: "[pfUI AddEffect Hook] Overriding Rip duration to 18s"
Instead of: "[pfUI AddEffect Hook] Overriding Rip duration to 10s"