### PR TITLE
Fix confirmation timing - confirm in cast hooks, not SPELLCAST_START

### DIFF
--- a/ComboPointTracker.lua
+++ b/ComboPointTracker.lua
@@ -392,6 +392,45 @@ function Extension.OnLoad()
     if CastSpellByName then
         Extension.Hook("CastSpellByName", "CastSpellByName_Hook")
     end
+
+    -- Hook global CastSpell and UseAction for confirmation
+    if _G.CastSpell then
+        local originalCastSpell = _G.CastSpell
+        _G.CastSpell = function(id, bookType)
+            -- Call original first
+            originalCastSpell(id, bookType)
+
+            -- Confirm tracking for combo spells
+            local spellName = GetSpellName(id, bookType)
+            if spellName and CleveRoids.IsComboScalingSpell(spellName) and
+               CleveRoids.ComboPointTracking[spellName] then
+                CleveRoids.ComboPointTracking[spellName].confirmed = true
+            end
+        end
+    end
+
+    if _G.UseAction then
+        local originalUseAction = _G.UseAction
+        _G.UseAction = function(slot, target, button)
+            -- Call original first
+            originalUseAction(slot, target, button)
+
+            -- Try to determine spell name from action slot
+            if not GetActionText(slot) and IsCurrentAction(slot) then
+                local spellName = GetActionText(slot)
+                if not spellName then
+                    -- Try to get from tooltip
+                    GameTooltip:SetAction(slot)
+                    spellName = GameTooltipTextLeft1:GetText()
+                end
+
+                if spellName and CleveRoids.IsComboScalingSpell(spellName) and
+                   CleveRoids.ComboPointTracking[spellName] then
+                    CleveRoids.ComboPointTracking[spellName].confirmed = true
+                end
+            end
+        end
+    end
 end
 
 -- Update combo points on relevant events
@@ -419,6 +458,12 @@ function Extension.OnSpellcastStart()
         -- Mark this tracking as confirmed (actual cast, not just evaluation)
         if CleveRoids.ComboPointTracking[spellName] then
             CleveRoids.ComboPointTracking[spellName].confirmed = true
+            if CleveRoids.debug then
+                DEFAULT_CHAT_FRAME:AddMessage(
+                    string.format("|cff00ff00[Confirmed]|r %s tracking confirmed (SPELLCAST_START)",
+                        spellName)
+                )
+            end
         end
     end
 end
@@ -458,6 +503,17 @@ end
 function Extension.CastSpellByName_Hook(spellName, onSelf)
     if spellName and CleveRoids.IsComboScalingSpell(spellName) then
         CleveRoids.TrackComboPointCast(spellName)
+
+        -- Confirm the tracking immediately - this only fires on actual casts
+        if CleveRoids.ComboPointTracking[spellName] then
+            CleveRoids.ComboPointTracking[spellName].confirmed = true
+            if CleveRoids.debug then
+                DEFAULT_CHAT_FRAME:AddMessage(
+                    string.format("|cff00ff00[Confirmed]|r %s tracking confirmed (CastSpellByName)",
+                        spellName)
+                )
+            end
+        end
     end
 end
 
@@ -465,6 +521,17 @@ end
 function Extension.CastSpell_Hook(spellName)
     if spellName and CleveRoids.IsComboScalingSpell(spellName) then
         CleveRoids.TrackComboPointCast(spellName)
+
+        -- Confirm the tracking immediately - this only fires on actual casts
+        if CleveRoids.ComboPointTracking[spellName] then
+            CleveRoids.ComboPointTracking[spellName].confirmed = true
+            if CleveRoids.debug then
+                DEFAULT_CHAT_FRAME:AddMessage(
+                    string.format("|cff00ff00[Confirmed]|r %s tracking confirmed (CleveRoids.CastSpell)",
+                        spellName)
+                )
+            end
+        end
     end
 end
 


### PR DESCRIPTION
CRITICAL FIX: For instant-cast spells, pfUI's AddEffect fires before SPELLCAST_START, so confirmed flag was never set in time.

Event sequence for instant casts:
1. CastSpellByName hook → TrackComboPointCast (confirmed=false)
2. pfUI AddPending
3. SPELLCAST_STOP (instant cast completes)
4. pfUI PersistPending → AddEffect (confirmed still false!) ✗
5. SPELLCAST_START may not fire for instants

Solution: Confirm tracking immediately when cast functions are called:
- CastSpellByName_Hook → confirmed=true
- CastSpell_Hook → confirmed=true
- Hook global CastSpell → confirmed=true
- Hook global UseAction → confirmed=true
- SPELLCAST_START → confirmed=true (backup)

Now pfUI AddEffect (step 4) sees confirmed=true ✓

Added debug output showing:
"[Confirmed] Rip tracking confirmed (CastSpellByName)"

This ensures tracking is confirmed BEFORE pfUI tries to use it.