### PR TITLE
CRITICAL: Add confirmation to DoCast hook

### DIFF
--- a/ComboPointTracker.lua
+++ b/ComboPointTracker.lua
@@ -541,20 +541,31 @@ if CleveRoids.DoCast then
     CleveRoids.DoCast = function(msg)
         -- Extract spell name from message
         local spellName = msg
-        
+
         -- Remove conditionals if present
         local condEnd = string.find(msg, "]")
         if condEnd then
             spellName = string.sub(msg, condEnd + 1)
         end
-        
+
         spellName = CleveRoids.Trim(spellName)
-        
+
         -- Track combo points if it's a scaling spell
         if CleveRoids.IsComboScalingSpell(spellName) then
             CleveRoids.TrackComboPointCast(spellName)
+
+            -- Confirm the tracking - DoCast only fires on actual casts
+            if CleveRoids.ComboPointTracking[spellName] then
+                CleveRoids.ComboPointTracking[spellName].confirmed = true
+                if CleveRoids.debug then
+                    DEFAULT_CHAT_FRAME:AddMessage(
+                        string.format("|cff00ff00[Confirmed]|r %s tracking confirmed (DoCast)",
+                            spellName)
+                    )
+                end
+            end
         end
-        
+
         -- Call original function
         return originalDoCast(msg)
     end


### PR DESCRIPTION
The issue: None of the CastSpellByName/CastSpell hooks were firing because CleveRoid macros go through DoCast, not the standard casting functions.

Evidence from user output:
- Many "ComboTrack: Rip cast with 5 CP" messages ✓ (TrackComboPointCast called)
- NO "[Confirmed]" messages ✗ (no hooks firing)
- "[pfUI AddEffect Hook] Ignoring Rip tracking (not confirmed)" ✗ (never confirmed)

The DoCast integration was calling TrackComboPointCast but NOT setting confirmed=true, so pfUI would always see unconfirmed tracking data.

Fix: Add confirmation in DoCast hook, just like all the other cast hooks.

Now when user casts via CleveRoid macros:
1. DoCast fires → TrackComboPointCast → confirmed=true ✓
2. pfUI AddEffect fires → sees confirmed=true → uses duration ✓