### PR TITLE
Fix combo points tracking for Vanilla WoW

### DIFF
--- a/ComboPointTracker.lua
+++ b/ComboPointTracker.lua
@@ -50,8 +50,10 @@ CleveRoids.ComboScalingSpells = {
 }
 
 -- Function to get current combo points
+-- Note: In Vanilla WoW 1.12, GetComboPoints() takes no parameters
+-- (The "player", "target" syntax is from TBC/WotLK)
 function CleveRoids.GetComboPoints()
-    return GetComboPoints("player", "target") or 0
+    return GetComboPoints() or 0
 end
 
 -- Update stored combo points (call this frequently)


### PR DESCRIPTION
The GetComboPoints() function was using TBC/WotLK syntax with two parameters ("player", "target"), which is incorrect for Vanilla WoW 1.12.

In Vanilla WoW, GetComboPoints() takes no parameters and returns the combo points on the current target.

This fixes the issue where macros were not tracking combo points correctly, especially for users without pfui or other addon dependencies.

Fixes combo point tracking for Rupture, Rip, and Kidney Shot spells.