### PR TITLE
Fix combo point tracking for all casts regardless of conditionals

### DIFF
--- a/ComboPointTracker.lua
+++ b/ComboPointTracker.lua
@@ -181,7 +181,20 @@ function CleveRoids.TrackComboPointCast(spellName)
         return
     end
 
+    -- Get current combo points, but if they're 0 (already consumed), use last known value
     local comboPoints = CleveRoids.GetComboPoints()
+
+    -- If combo points are 0, use lastComboPoints as fallback
+    if comboPoints == 0 and CleveRoids.lastComboPoints > 0 then
+        comboPoints = CleveRoids.lastComboPoints
+        if CleveRoids.debug then
+            DEFAULT_CHAT_FRAME:AddMessage(
+                string.format("|cffff9900CleveRoids:|r ComboTrack: Using lastComboPoints (%d) for %s",
+                    comboPoints, spellName)
+            )
+        end
+    end
+
     local duration = CleveRoids.CalculateComboScaledDuration(spellName, comboPoints)
     local currentTime = GetTime()
 
@@ -465,6 +478,18 @@ function Extension.OnSpellcastStart()
     -- Track combo points at cast start for channeled combo spells
     local spellName = arg1
     if spellName and CleveRoids.IsComboScalingSpell(spellName) then
+        -- Capture current combo points BEFORE the spell cast
+        local currentCP = CleveRoids.GetComboPoints()
+        if currentCP and currentCP > 0 then
+            CleveRoids.lastComboPoints = currentCP
+            if CleveRoids.debug then
+                DEFAULT_CHAT_FRAME:AddMessage(
+                    string.format("|cffaaaaff[Pre-Cast]|r Captured %d combo points before casting %s",
+                        currentCP, spellName)
+                )
+            end
+        end
+
         CleveRoids.TrackComboPointCast(spellName)
 
         -- Mark this tracking as confirmed (actual cast, not just evaluation)
@@ -514,6 +539,18 @@ end
 -- Hook CastSpellByName to track combo points
 function Extension.CastSpellByName_Hook(spellName, onSelf)
     if spellName and CleveRoids.IsComboScalingSpell(spellName) then
+        -- Capture current combo points BEFORE the spell cast
+        local currentCP = CleveRoids.GetComboPoints()
+        if currentCP and currentCP > 0 then
+            CleveRoids.lastComboPoints = currentCP
+            if CleveRoids.debug then
+                DEFAULT_CHAT_FRAME:AddMessage(
+                    string.format("|cffaaaaff[Pre-Cast]|r Captured %d combo points before casting %s",
+                        currentCP, spellName)
+                )
+            end
+        end
+
         CleveRoids.TrackComboPointCast(spellName)
 
         -- Confirm the tracking immediately - this only fires on actual casts
@@ -532,6 +569,18 @@ end
 -- Hook CleveRoids.CastSpell if it exists
 function Extension.CastSpell_Hook(spellName)
     if spellName and CleveRoids.IsComboScalingSpell(spellName) then
+        -- Capture current combo points BEFORE the spell cast
+        local currentCP = CleveRoids.GetComboPoints()
+        if currentCP and currentCP > 0 then
+            CleveRoids.lastComboPoints = currentCP
+            if CleveRoids.debug then
+                DEFAULT_CHAT_FRAME:AddMessage(
+                    string.format("|cffaaaaff[Pre-Cast]|r Captured %d combo points before casting %s",
+                        currentCP, spellName)
+                )
+            end
+        end
+
         CleveRoids.TrackComboPointCast(spellName)
 
         -- Confirm the tracking immediately - this only fires on actual casts
@@ -564,6 +613,18 @@ if CleveRoids.DoCast then
 
         -- Track combo points if it's a scaling spell
         if CleveRoids.IsComboScalingSpell(spellName) then
+            -- Capture current combo points BEFORE the spell cast
+            local currentCP = CleveRoids.GetComboPoints()
+            if currentCP and currentCP > 0 then
+                CleveRoids.lastComboPoints = currentCP
+                if CleveRoids.debug then
+                    DEFAULT_CHAT_FRAME:AddMessage(
+                        string.format("|cffaaaaff[Pre-Cast]|r Captured %d combo points before casting %s",
+                            currentCP, spellName)
+                    )
+                end
+            end
+
             CleveRoids.TrackComboPointCast(spellName)
 
             -- Confirm the tracking - DoCast only fires on actual casts


### PR DESCRIPTION
Previously, combo point tracking only worked reliably when spells were cast with conditionals (e.g., /cast [combo:>0]Rip) but not for direct casts (e.g., /cast Rip). This was because combo points are consumed immediately when a spell is cast, so by the time the tracking code ran, GetComboPoints() would return 0.

Changes:
- Updated TrackComboPointCast() to fall back to lastComboPoints when GetComboPoints() returns 0, ensuring the correct combo point count is used even if the points have already been consumed
- Modified all spell cast hooks (CastSpellByName_Hook, CastSpell_Hook, DoCast integration, OnSpellcastStart) to capture the current combo points into lastComboPoints BEFORE the spell is cast
- Added debug messages to track when combo points are captured and when fallback values are used

This ensures that all casts of combo point finisher spells (Rip, Rupture, Kidney Shot) are tracked correctly with the actual number of combo points used, regardless of whether they're cast through conditionals or directly.