### PR TITLE
Fix combo point tracking to use continuous tracking system

### DIFF
--- a/ComboPointTracker.lua
+++ b/ComboPointTracker.lua
@@ -181,7 +181,20 @@ function CleveRoids.TrackComboPointCast(spellName)
         return
     end
 
+    -- Get current combo points, but if they're 0 (already consumed), use last known value
     local comboPoints = CleveRoids.GetComboPoints()
+
+    -- If combo points are 0, use lastComboPoints as fallback
+    if comboPoints == 0 and CleveRoids.lastComboPoints > 0 then
+        comboPoints = CleveRoids.lastComboPoints
+        if CleveRoids.debug then
+            DEFAULT_CHAT_FRAME:AddMessage(
+                string.format("|cffff9900CleveRoids:|r ComboTrack: Using lastComboPoints (%d) for %s",
+                    comboPoints, spellName)
+            )
+        end
+    end
+
     local duration = CleveRoids.CalculateComboScaledDuration(spellName, comboPoints)
     local currentTime = GetTime()
 


### PR DESCRIPTION
Previously, combo point tracking attempted to capture combo points at cast time in the hooks, but this approach failed because hooks run after the spell has already consumed the combo points.

The solution is to rely entirely on the existing UpdateComboPoints() system, which runs continuously via OnUpdate and PLAYER_COMBO_POINTS events. This system tracks combo points AS THEY ARE GENERATED on the target, storing them in lastComboPoints before any spell can consume them.

Changes:
- Removed manual combo point capture logic from all hooks (CastSpellByName_Hook, CastSpell_Hook, DoCast, OnSpellcastStart)
- TrackComboPointCast() now relies solely on the continuous tracking system, falling back to lastComboPoints when GetComboPoints() returns 0 (because points were already consumed)
- UpdateComboPoints() continues to run on every frame, capturing combo points as they appear on the target

This ensures that all casts of combo point finisher spells (Rip, Rupture, Kidney Shot) are tracked correctly with the actual number of combo points used, regardless of whether they're cast through conditionals (e.g., /cast [combo:>0]Rip) or directly (e.g., /cast Rip).