### PR TITLE
add [bg]/[nobg] conditional for battleground detection

### DIFF
--- a/Conditionals.lua
+++ b/Conditionals.lua
@@ -7331,6 +7331,24 @@ CleveRoids.Keywords = {
         return IsResting() == nil
     end,
 
+    bg = function()
+        for i = 1, MAX_BATTLEFIELD_QUEUES do
+            if GetBattlefieldStatus(i) == "active" then
+                return true
+            end
+        end
+        return false
+    end,
+
+    nobg = function()
+        for i = 1, MAX_BATTLEFIELD_QUEUES do
+            if GetBattlefieldStatus(i) == "active" then
+                return false
+            end
+        end
+        return true
+    end,
+
     stat = function(conditionals)
         return Multi(conditionals.stat, function(args)
             if type(args) ~= "table" or not args.name then

--- a/Core.lua
+++ b/Core.lua
@@ -150,6 +150,8 @@ local BOOLEAN_CONDITIONALS = {
     stopattack = true,
     pet = true,
     nopet = true,
+    bg = true,
+    nobg = true,
 }
 
 local requirementCheckFrame = CreateFrame("Frame")


### PR DESCRIPTION
## Summary

- Adds `[bg]` and `[nobg]` boolean conditionals
- Uses `GetBattlefieldStatus` across all queue slots — returns true when any slot reports `"active"`, indicating the player is inside a battleground instance
- Useful for macros that need to behave differently in BGs vs. PvE/world (e.g. swapping targeting priorities, disabling pet auto-attack pulls, etc.)